### PR TITLE
Sideways fix 2

### DIFF
--- a/planners/inter/sideways_inter/src/sideways_inter.cpp
+++ b/planners/inter/sideways_inter/src/sideways_inter.cpp
@@ -100,7 +100,7 @@ namespace sideways_inter
                 ROS_ERROR("AVOIDED COLLISION WITH OBSTACLE. CONTINUE NORMAL PLANNING");
                 new_goal_set_ = false;
                 plan = plan_;
-                //return 0;
+                
             }
             // calculate distance to temporary goal
             double distance_to_temp_goal_ = std::sqrt(std::pow(temp_goal_.pose.position.x - robot_x, 2) + std::pow(temp_goal_.pose.position.y - robot_y, 2));
@@ -109,10 +109,10 @@ namespace sideways_inter
             plan.clear();
             plan.push_back(temp_goal_);
 
-            if (distance_to_temp_goal_ <= temp_goal_tolerance_)
+            if (distance_to_temp_goal_ <= temp_goal_tolerance_ || wall_near)
             {
                 // Set speed to 0.0 when reaching temp_goal
-                ROS_INFO("Reached temp_goal. Resetting goal and setting speed to 0.0 for 5 seconds.");
+                ROS_ERROR("Reached temp_goal. Resetting goal and setting speed to 0.0 for 5 seconds.");
 
                 speed_ = 0.0;
 
@@ -180,10 +180,10 @@ namespace sideways_inter
     {
         ROS_INFO("Resumed with the previous speed.");
 
-        // Setzen Sie die Geschwindigkeit auf den vorherigen Wert (last_speed_)
+        // set speed to the previous value (last_speed_)
         speed_ = last_speed_;
 
-        // Setzen Sie new_goal_set_ auf false, um den nächsten Durchlauf zu ermöglichen
+        // set variable to false for next loop
         new_goal_set_ = false;
     }
 
@@ -290,14 +290,14 @@ namespace sideways_inter
 
                 // Check if speed is set to zero, then start the timer
                 if (speed_ == 0.0)
-                {
+                {               
                     // Start Timer
                     wait_timer = nh_.createTimer(ros::Duration(2.5), &SidewaysInter::resumeDriving, this);
                 }
             }
-            // Unlock and sleep
+            // Unlock 
             lock.unlock();
-            rate.sleep();
+           
         }
     }
 

--- a/planners/inter/sideways_inter/src/sideways_inter.cpp
+++ b/planners/inter/sideways_inter/src/sideways_inter.cpp
@@ -178,13 +178,14 @@ namespace sideways_inter
 
     void SidewaysInter::resumeDriving(const ros::TimerEvent&)
     {
-        ROS_INFO("Resumed with the previous speed.");
+        ROS_ERROR("Resumed with the previous speed.");
 
         // set speed to the previous value (last_speed_)
         speed_ = last_speed_;
 
         // set variable to false for next loop
         new_goal_set_ = false;
+
     }
 
 
@@ -291,8 +292,9 @@ namespace sideways_inter
                 // Check if speed is set to zero, then start the timer
                 if (speed_ == 0.0)
                 {               
-                    // Start Timer
-                    wait_timer = nh_.createTimer(ros::Duration(2.5), &SidewaysInter::resumeDriving, this);
+                    // Start Timer and configure it as oneshot time (oneshot=true)
+                    wait_timer = nh_.createTimer(ros::Duration(2.5), &SidewaysInter::resumeDriving, this,true);
+                    
                 }
             }
             // Unlock 


### PR DESCRIPTION
more robust sideways behavior, since the waiting function sometimes had its issues in the corridor and when confronting many peds after another in a short period of time. Added to the ros::timer  the oneshot configuration  and deleted rate.sleep() which fixxed this issue. 

@voshch 